### PR TITLE
Fix schema is_referenceable

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cadom"
-version = "0.4.0"
+version = "0.4.1"
 edition = "2018"
 authors = ["Artyom Sakharilenko <kryvashek@gmail.com>"]
 description = "Some error-processing helpers for Rust"

--- a/src/serde.rs
+++ b/src/serde.rs
@@ -40,9 +40,10 @@ impl<O: StdError + Serialize> Serialize for Decay<O> {
 #[cfg(feature = "schema")]
 #[cfg_attr(docsrs, doc(cfg(all(feature = "serde", feature = "schema"))))]
 impl<O: StdError + Serialize + JsonSchema> JsonSchema for Decay<O> {
+    /// Always returns true since [Decay] is complex enough to be referenced when possible.
     #[inline]
     fn is_referenceable() -> bool {
-        false
+        true
     }
 
     /// Will return name like "Decay(<smth>)", where <smth> is the type O schema name.


### PR DESCRIPTION
Associated function `is_referenceable` should always return true for `Decay`.