### PR TITLE
Decay root

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cadom"
-version = "0.4.1"
+version = "0.4.2"
 edition = "2018"
 authors = ["Artyom Sakharilenko <kryvashek@gmail.com>"]
 description = "Some error-processing helpers for Rust"


### PR DESCRIPTION
Associated function `Decay::root` which returns `DecayRoot` examplar helping to get access to the very root error.