### PR TITLE
Fix missing decay root export

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cadom"
-version = "0.4.2"
+version = "0.4.3"
 edition = "2018"
 authors = ["Artyom Sakharilenko <kryvashek@gmail.com>"]
 description = "Some error-processing helpers for Rust"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,6 +12,6 @@ mod serde;
 
 #[cfg(feature = "serde")]
 pub use self::serde::{DecayDeser, DecayDeserInner, DecayDeserItem};
-pub use decay::{Decay, IntoDecay};
+pub use decay::{Decay, DecayRoot, IntoDecay};
 pub use note::Note;
 pub use place::{CodePlace, CodePlaceChain};


### PR DESCRIPTION
`DecayRoot` has been added into `pub use decay::_` statement.